### PR TITLE
Update Core.cs

### DIFF
--- a/src/Systems/Core.cs
+++ b/src/Systems/Core.cs
@@ -72,7 +72,7 @@ public class Core : ModSystem
             obj.EnsureAttributesNotNull();
             obj.SetAttribute(GroundRackable, true);
 
-            if (transform != null)
+            if (obj.Attributes?.KeyExists(OnGroundRackTransform) == false && transform != null)
             {
                 obj.SetAttribute(OnGroundRackTransform, transform);
             }
@@ -90,7 +90,7 @@ public class Core : ModSystem
             obj.EnsureAttributesNotNull();
             obj.SetAttribute(ShelvableOne, true);
 
-            if (transform != null)
+            if (obj.Attributes?.KeyExists(OnShelfOneTransform) == false && transform != null)
             {
                 obj.SetAttribute(OnShelfOneTransform, transform);
             }


### PR DESCRIPTION
Adds checks to PatchGroundRackable and PatchShelvableOne to only apply transform if one doesn't already exist.  This prevents overwriting user patches with the built-in ones.